### PR TITLE
Flexibilize timeout for execution

### DIFF
--- a/d2lbook/build.py
+++ b/d2lbook/build.py
@@ -28,9 +28,11 @@ def build():
     parser = argparse.ArgumentParser(description='Build the documents')
     parser.add_argument('commands', nargs='+', choices=commands)
     parser.add_argument('--tab', default=None, help='The tab to build, if multi-tab is enabled.')
+    parser.add_argument('--timeout', type=int,default=1200,help="Timeout for excution. Default: 1200 (s). Set timeout -1 to disable timeout.")
     args = parser.parse_args(sys.argv[2:])
     config = Config(tab=args.tab)
-    builder = Builder(config)
+    timeout = args.timeout
+    builder = Builder(config, timeout)
     for cmd in args.commands:
         getattr(builder, cmd)()
 
@@ -51,8 +53,9 @@ def _once(func):
     return warp
 
 class Builder(object):
-    def __init__(self, config):
+    def __init__(self, config, timeout):
         self.config = config
+        self.timeout = timeout
         mkdir(self.config.tgt_dir)
         self.sphinx_opts = '-j 4'
         if config.build['warning_is_error'].lower() == 'true':
@@ -139,7 +142,7 @@ class Builder(object):
                          get_time_diff(eval_tik, tik), src, tgt)
             mkdir(os.path.dirname(tgt))
             run_cells = self.config.build['eval_notebook'].lower()=='true'
-            _process_and_eval_notebook(src, tgt, run_cells, self.config)
+            _process_and_eval_notebook(src, tgt, run_cells, self.config, self.timeout)
             tok = datetime.datetime.now()
             logging.info('Finished in %s', get_time_diff(tik, tok))
 


### PR DESCRIPTION
Leave room for users to choose `timeout` when `build`.

`eval` for `chapter_generative-adversarial-networks/dcgan_vn.ipynb` on my system takes longer time (3000s) than the default timeout (1200s). Hence, the error occurred:
```
[d2lbook:build.py:L139] INFO   [1/38, 00:00:01] Evaluating ./chapter_generative-adversarial-networks/dcgan_vn.md, save as _build/eval/chapter_generative-adversarial-networks/dcgan_vn.ipynb
[d2lbook:execute.py:L404] INFO   Executing notebook with kernel: python
[d2lbook:execute.py:L499] ERROR  Timeout waiting for execute reply (1200s).
Traceback (most recent call last):
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/bin/d2lbook", line 8, in <module>
    sys.exit(main())
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/main.py", line 24, in main
    commands[args.command[0]]()
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 35, in build
    getattr(builder, cmd)()
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 263, in html
    self.rst()
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 242, in rst
    self.eval()
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 142, in eval
    _process_and_eval_notebook(src, tgt, run_cells, self.config)
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/d2lbook/build.py", line 444, in _process_and_eval_notebook
    notedown.run(nb, timeout)
  File "/master/home/hnguyent/miniconda3/envs/d2lenv/lib/python3.7/site-packages/notedown/notedown.py", line 48, in run
    notebook, resources = executor.preprocess(notebook, resources={})
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/execute.py", line 405, in preprocess
    nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/base.py", line 69, in preprocess
    nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/execute.py", line 438, in preprocess_cell
    reply, outputs = self.run_cell(cell, cell_index, store_history)
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/execute.py", line 571, in run_cell
    if self._passed_deadline(deadline):
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/execute.py", line 541, in _passed_deadline
    self._handle_timeout()
  File "/master/home/hnguyent/.local/lib/python3.7/site-packages/nbconvert/preprocessors/execute.py", line 504, in _handle_timeout
    raise TimeoutError("Cell execution timed out")
TimeoutError: Cell execution timed out
srun: error: monet: task 0: Exited with exit code 1
```

I think that it is better to give the users the flexibility to choose `timeout` when building.

For example:
```
d2lbook build html --timeout 3600
```