### PR TITLE
[Fix] Rename "add_javascript" --> "add_js_file" and "add_stylesheet" --> "add_css_file"

### DIFF
--- a/d2lbook/sphinx_template.py
+++ b/d2lbook/sphinx_template.py
@@ -101,9 +101,9 @@ MONO_FONT
 SPHINX_CONFIGS
 
 def setup(app):
-    # app.add_javascript('https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js')
-    app.add_javascript('d2l.js')
-    app.add_stylesheet('d2l.css')
+    # app.add_js_file('https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js')
+    app.add_js_file('d2l.js')
+    app.add_css_file('d2l.css')
     import mxtheme
     app.add_directive('card', mxtheme.CardDirective)
 """


### PR DESCRIPTION
Recently, Sphinx deprecated the usage of "add_javascript" and "add_stylesheet". 

`add_js_file` and `add_css_file` are the new name for these two functions.

See also:
- https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file
- https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file

The renaming happened in Sphinx 1.8 and d2lbook supports sphinx>=2.2.1 so the change should be a backward compatible change of downstream users of d2lbook.