### PR TITLE
Fix #39 d2lbook translate failure

### DIFF
--- a/d2lbook/translate.py
+++ b/d2lbook/translate.py
@@ -29,7 +29,7 @@ class Translate(object):
         if os.path.exists(self.repo_dir):
             self.repo = git.Repo(self.repo_dir)
             logging.info(f'Pulling from {self.url} into {self.repo_dir}')
-            # reset to origin/master before pulling updates
+            # Reset to origin/master before pulling updates
             self.repo.git.reset('--hard', self.repo.remotes.origin.name + '/' + self.repo.active_branch.name)
             self.repo.remotes.origin.pull()
         else:

--- a/d2lbook/translate.py
+++ b/d2lbook/translate.py
@@ -29,6 +29,8 @@ class Translate(object):
         if os.path.exists(self.repo_dir):
             self.repo = git.Repo(self.repo_dir)
             logging.info(f'Pulling from {self.url} into {self.repo_dir}')
+            # reset to origin/master before pulling updates
+            self.repo.git.reset('--hard', self.repo.remotes.origin.name + '/' + self.repo.active_branch.name)
             self.repo.remotes.origin.pull()
         else:
             logging.info(f'Clone {self.url} into {self.repo_dir}')


### PR DESCRIPTION
d2lbook translate was failing due to merge conflicts if src repo already exists with the following error:
```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git pull -v origin
```
Closes #39.