### PR TITLE
fix the cuda invisible error of paddle

### DIFF
--- a/d2lbook/resource.py
+++ b/d2lbook/resource.py
@@ -251,6 +251,6 @@ class Scheduler():
 def _target(gpus, target, *args):
     if not gpus:
         # it will triggler an runtime error if target actually uses a gpu
-        gpus = [-1]
+        gpus = [""]
     os.environ['CUDA_VISIBLE_DEVICES'] = ','.join([str(g) for g in gpus])
     return target(*args)


### PR DESCRIPTION
With this pr, we can avoid the "no cuda detected" error and all codes can be ran on cpus automatically if not specifying the gpus. As I tested locally, it will not affect other dl libraries. 

@AnirudhDagar  Once merged, you can update the d2lbook lib on the CI server. Thank you.
