### PR TITLE
Feat: Enable d2l default tab even if few notebooks have missing default

### DIFF
--- a/d2lbook/build.py
+++ b/d2lbook/build.py
@@ -234,10 +234,12 @@ class Builder(object):
         updated_notebooks = get_updated_files(notebooks, default_eval_dir,
                                               self.config.eval_dir, 'ipynb',
                                               'ipynb')
-        tab_dirs = [
-            default_eval_dir + '_' + tab for tab in self.config.tabs[1:]]
+        # All tab notebooks need to be verified with file size for skipping
+        tab_dirs = [default_eval_dir]
+        for tab in self.config.tabs[1:]:
+            tab_dirs.append(default_eval_dir + '_' + tab)
         for default, merged in updated_notebooks:
-            src_notebooks = [default]
+            src_notebooks = []
             for tab_dir in tab_dirs:
                 fname = os.path.join(
                     tab_dir, os.path.relpath(default, default_eval_dir))


### PR DESCRIPTION
Enable primary tabs of our choice feature on d2lbook. Earlier if the tab was missing, for example pytorch recommender system is not available; the html build failed). This issue has been fixed in this PR by checking all tabs equally for their file size.

When a notebook has a missing default tab, we automatically fallback to the tabs which are present. Example in recommender systems, pytorch is missing so mxnet will become default there.

See http://preview.d2l.ai/d2l-en/PR-2098/ andd http://ci.d2l.ai/blue/organizations/jenkins/d2l-en/detail/PR-2098/6/pipeline/ for the demo pytorch default version of d2l.