### PR TITLE
BLD: Remove nbformat and nbconvert dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ requirements = [
     'regex',
     'sphinx',
     'recommonmark',
-    'nbformat',
-    'nbconvert',
     'sphinxcontrib-bibtex==2.4.2', # >=2.2 to enable citet and citep
     'pybtex-apa-style',
     'mu-notedown',


### PR DESCRIPTION
nbformat and nbconvert are already mu-notedown dependencies, which can be safely removed.
Ref #59 for more details.

cc @astonzhang 