### PR TITLE
Fix #66: Update d2lbook docs about Jupyter Book

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 # D2L-Book: A Toolkit for Hands-on Books
 
 The D2L Book (`d2lbook`) package helps you build and publish **a book
-with Python codes**, or **Python package documents with tutorials**. You can
+with Python code blocks**, or **Python package documents with tutorials**. You can
 check [Dive into Deep Learning](https://d2l.ai/) for a book
 example and [AutoGluon](https://autogluon.mxnet.io/) for a package document site
 example.
 
-The `d2lbook` is designed to meet the following two requirements:
+`d2lbook` is designed to meet the following two requirements:
 
-- Your book may contain **a large amount of Python codes** and you
+- Your book may contain **a large amount of Python code** and you
   expect your readers to run them. Or your package documents have **multiple
   tutorials** to walk readers through your package usage through examples.
-  These codes should be runnable and maintainable.
+  The code should be runnable and maintainable.
 
 - You would like to publish **both a HTML website and a printable PDF
   version**. You expect the website should be modern, searchable and mobile
@@ -27,20 +27,16 @@ features include:
 - Using [markdown](https://daringfireball.net/projects/markdown/) for your contents.
 - A minimal configuration file to customize the building so you can focus on the
   contents.
-- Evaluating all codes to obtain their output before publishing to validate the
-  correctness. We only evaluate the updated codes to save cost.
+- Evaluating all code blocks to obtain their output before publishing to validate the
+  correctness. By default, `d2lbook` only evaluates the updated code blocks to save cost.
 - Being able to reference sections, figure, tables, equations, function, and
   class.
 - Pipelines to publish your website through Github or AWS.
 
 If `d2lbook` does not fit your requirements, you may check the following tools:
 
-- [Jupyter book](https://jupyterbook.org/intro): very similar to `d2lbook` for
-  publishing Jupyter notebooks. Two main design differences are 1) `d2lbook`
-  encourage you to use markdown file format and remove all code outputs before
-  saving notebooks. 2) `d2lbook` uses Sphinx instead of Jekyll adopted by
-  Jupyter book to build the document.
-  Jekyll is easier to customize the theme, while Sphinx has better supports for PDF and analyzing Python codes.
+- [Jupyter Book](https://jupyterbook.org): A similar tool for building books 
+  from computational material with Jupyter Notebooks and MyST Markdown.
 - [gitbook](https://www.gitbook.com/): very convenient to push a book written
   with markdown if you don't need to run them as Jupyter notebooks.
 - [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html), a Sphinx


### PR DESCRIPTION
Docs updated to address the comments in #66, plus a few typos fixed.